### PR TITLE
feat: allow autoprefix to be disabled per request

### DIFF
--- a/src/types/disable-auto-prefix.type.ts
+++ b/src/types/disable-auto-prefix.type.ts
@@ -1,0 +1,1 @@
+export type DisableAutoPrefix = { disableAutoPrefix: true };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './download-options.type';
 export * from './object-command-options.type';
 export * from './s3-config.type';
 export * from './signed-url.type';
+export * from './disable-auto-prefix.type';

--- a/src/types/object-command-options.type.ts
+++ b/src/types/object-command-options.type.ts
@@ -5,9 +5,11 @@ import {
   ListObjectsCommandInput,
   PutObjectCommandInput,
 } from '@aws-sdk/client-s3';
+import { DisableAutoPrefix } from './disable-auto-prefix.type';
 
-export type GetObjectOptions = Omit<GetObjectCommandInput, 'Bucket' | 'Key'>;
-export type DeleteObjectsOptions = Omit<DeleteObjectsCommandInput, 'Bucket' | 'Delete'>;
-export type PutObjectOptions = Omit<PutObjectCommandInput, 'Bucket' | 'Body' | 'Key'>;
-export type DeleteObjectOptions = Omit<DeleteObjectCommandInput, 'Bucket' | 'Key'>;
-export type ListObjectOptions = Omit<ListObjectsCommandInput, 'Bucket'>;
+export type GetObjectOptions = Omit<GetObjectCommandInput, 'Bucket' | 'Key'> & DisableAutoPrefix;
+export type DeleteObjectsOptions = Omit<DeleteObjectsCommandInput, 'Bucket' | 'Delete'> & DisableAutoPrefix;
+export type PutObjectOptions = Omit<PutObjectCommandInput, 'Bucket' | 'Body' | 'Key'> & DisableAutoPrefix;
+export type DeleteObjectOptions = Omit<DeleteObjectCommandInput, 'Bucket' | 'Key'> & DisableAutoPrefix;
+export type ListObjectOptions = Omit<ListObjectsCommandInput, 'Bucket'> & DisableAutoPrefix;
+export type OptionsWithAutoPrefix = PutObjectOptions | DeleteObjectOptions | DeleteObjectsOptions | GetObjectOptions;


### PR DESCRIPTION
# Description
At times we need the ability to disable auto prefixing for specific object operations, the introduction of `disableAutoPrefix` option was needed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] E2E tests

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
