### PR TITLE
Fix deletion when no files with the specified prefix are found

### DIFF
--- a/site/docs/deletion-helper.md
+++ b/site/docs/deletion-helper.md
@@ -129,6 +129,13 @@ interface ListObjectsV2Request {
 }
 ```
 
+## Return value
+
+The return value of the function is `Promise<DeleteObjectsOutput[]>` if `logDeletedObjects` is true.
+Otherwise, the return value is `Promise<boolean>`.
+
+If no files are found with the specified `prefix`, the return value is `false`.
+
 ## Examples
 
 ### Delete all objects from a folder with default options

--- a/src/utils/deletion.service.ts
+++ b/src/utils/deletion.service.ts
@@ -37,6 +37,10 @@ export class DeletionService {
         ...listOptions,
       });
 
+      if (!data.Contents) {
+        return false;
+      }
+
       const response = await this.client.send(
         new DeleteObjectsCommand({
           Bucket: bucket,

--- a/tests/e2e/deletion-service.e2e.test.ts
+++ b/tests/e2e/deletion-service.e2e.test.ts
@@ -56,7 +56,30 @@ describe('Deletion service', () => {
 
     const result = await deletionHelperService.deleteObjectsByPrefix(bucketName, 'delete-prefix');
 
+    expect(result).toEqual(true);
+  });
+
+  it('should return an array with the output of the deleted files by prefix from a bucket', async () => {
+    await objectService.putObjectFromPath(
+      bucketName,
+      path.resolve(testPath, 'test.txt'),
+      'delete-prefix/test-file-to-delete.txt',
+    );
+    await objectService.putObjectFromPath(
+      bucketName,
+      path.resolve(testPath, 'test.txt'),
+      'delete-prefix/test-file-to-delete-2.txt',
+    );
+    await objectService.putObjectFromPath(
+      bucketName,
+      path.resolve(testPath, 'test.txt'),
+      'delete-prefix/nested/test-file-to-delete-2.txt',
+    );
+
+    const result = await deletionHelperService.deleteObjectsByPrefix(bucketName, 'delete-prefix', true);
+
     expect(result).not.toEqual(null);
+    expect(result).toBeInstanceOf(Array);
   });
 
   it('should be able to delete paginated files recursively by prefix from a bucket', async () => {
@@ -82,5 +105,11 @@ describe('Deletion service', () => {
     );
 
     expect(result).toEqual(true);
+  });
+
+  it('should return false when no files with the specified prefix are found in the bucket', async () => {
+    const result = await deletionHelperService.deleteObjectsByPrefix(bucketName, 'not-existing-prefix');
+
+    expect(result).toEqual(false);
   });
 });


### PR DESCRIPTION
# Description

When trying to delete files with a specific prefix, there may be no such files, thus leading to an error. Now if no files are found, there will be no attempt to delete them.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] E2E tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
